### PR TITLE
Downgrade android sdk to 0.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -129,5 +129,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.paypal.checkout:android-sdk:0.6.2'
+  implementation 'com.paypal.checkout:android-sdk:0.6.1'
 }


### PR DESCRIPTION
It looks like since 0.6.2 version, the paypal button does not appear correctly after the first load on Android (cf : https://github.com/paypal/android-checkout-sdk/issues/134).

To solve this issue, we decided to downgrade the Android SDK version to 0.6.1 while Paypal fixing this issue.

Issue linked to this problem on this repo : https://github.com/keplr-team/paypal-react-native/issues/11