### PR TITLE
fix: add data collector dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,4 +133,5 @@ dependencies {
     exclude group: 'org.jfrog.cardinalcommerce.gradle', module: 'cardinalmobilesdk'
   }
   implementation 'org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-2'
+  implementation 'com.paypal.android.sdk:data-collector:3.21.0'
 }


### PR DESCRIPTION
Add data-collector dependency in 3.21.0 to solve warning message on the Google Play store

(c.f : issue https://github.com/paypal/android-checkout-sdk/issues/281)